### PR TITLE
Make updating icons happen on demand and not on every build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/SorenHolstHansen/phosphor-leptos"
 keywords = ["icons", "leptos", "phosphor"]
 edition = "2021"
 license = "MIT"
+exclude = ["/core"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 leptos = "0.5.1"
 
-[build-dependencies]
-regex = "1.10.2"
-convert_case = "0.6.0"
+[workspace]
+members = ["xtask"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+regex = "1.10.2"
+convert_case = "0.6.0"
+clap = { version = "4.4.10", features = ["derive"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,21 @@
+use clap::Parser;
+
+mod update;
+
+#[derive(Parser)]
+enum Command {
+    /// Re-generate the icon components from the original SVG files
+    Update,
+}
+
+impl Command {
+    fn run(&self) {
+        match self {
+            Self::Update => update::run(),
+        }
+    }
+}
+
+fn main() {
+    Command::parse().run()
+}

--- a/xtask/src/update.rs
+++ b/xtask/src/update.rs
@@ -57,7 +57,7 @@ pub fn {component_name}(
 const OUTPUT_DIR: &str = "src/icons";
 const ASSETS_DIR: &str = "core/assets";
 
-fn main() {
+pub fn run() {
     let svg_tag_regex = Regex::new(r"<svg.*?>").unwrap();
     let svg_closing_tag_regex = Regex::new(r"</svg>").unwrap();
     // Clean up the icons folder


### PR DESCRIPTION
This PR converts what previously was a `build.rs` file to a task using the [`xtask`](https://github.com/matklad/cargo-xtask) pattern.

You can now update and re-generate the icons from SVG files by running `cargo xtask update`.

The usage of `clap` may be an overkill — let me know if you'd prefer to keep it simple and avoid the dependency!

Fixes: https://github.com/SorenHolstHansen/phosphor-leptos/issues/3