### PR TITLE
Make compatible with leptos 0.7.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/core"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = "0.6"
+leptos = "0.7.1"
 
 [workspace]
 members = ["xtask"]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ fn MyComponent() -> impl IntoView {
 
 ### Props
 
-All of the props are `MaybeSignal`s so they can be static or reactive.
+All of the props are `Signal`s so they can be static or reactive.
 
 - **color?**: `string` – Icon stroke/fill color. Can be any CSS color string, including `hex`, `rgb`, `rgba`, `hsl`, `hsla`, named colors, or the special `currentColor` variable.
 - **size?**: `number | string` – Icon height & width. As with standard React elements, this can be a number, or a string with units in `px`, `%`, `em`, `rem`, `pt`, `cm`, `mm`, `in`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc = r" You can explore the available icons at [phosphoricons.com](https://phosphoricons.com)."]
 #![doc = r""]
 #![doc = r" ```"]
-#![doc = r" use leptos::*;"]
+#![doc = r" use leptos::prelude::*;;"]
 #![doc = r" use phosphor_leptos::{Icon, IconWeight, HORSE, HEART, CUBE};"]
 #![doc = r""]
 #![doc = r" #[component]"]
@@ -15,7 +15,8 @@
 #![doc = r"     }"]
 #![doc = r" }"]
 #![doc = r" ```"]
-use leptos::*;
+use leptos::prelude::*;
+use leptos::text_prop::TextProp;
 mod icons;
 pub use icons::*;
 #[doc = r" An icon's weight or style."]
@@ -39,7 +40,7 @@ impl IconWeightData {
     #[doc = r" an SVG component's `inner_html` property."]
     #[doc = r""]
     #[doc = r" ```"]
-    #[doc = r" # use leptos::*;"]
+    #[doc = r" # use leptos::prelude::*;"]
     #[doc = r" # #[component]"]
     #[doc = r" # fn MyComponent() -> impl IntoView {"]
     #[doc = r" use phosphor_leptos::{ACORN, IconWeight};"]
@@ -69,7 +70,7 @@ pub type IconData = &'static IconWeightData;
 #[doc = r" A thin wrapper around `<svg />` for displaying Phosphor icons."]
 #[doc = r""]
 #[doc = r" ```"]
-#[doc = r" use leptos::*;"]
+#[doc = r" use leptos::prelude::*;;"]
 #[doc = r" use phosphor_leptos::{Icon, IconWeight, HORSE, HEART, CUBE};"]
 #[doc = r""]
 #[doc = r" #[component]"]
@@ -87,8 +88,8 @@ pub fn Icon(
     #[doc = r#" Icon weight/style. This can also be used, for example, to "toggle" an icon's state:"#]
     #[doc = r" a rating component could use Stars with [IconWeight::Regular] to denote an empty star,"]
     #[doc = r" and [IconWeight::Fill] to denote a filled star."]
-    # [prop (into , default = MaybeSignal :: Static (IconWeight :: Regular))]
-    weight: MaybeSignal<IconWeight>,
+    # [prop (into , default = Signal::from (IconWeight::Regular))]
+    weight: Signal<IconWeight>,
     #[doc = r" Icon height & width. As with standard React elements,"]
     #[doc = r" this can be a number, or a string with units in"]
     #[doc = r" `px`, `%`, `em`, `rem`, `pt`, `cm`, `mm`, `in`."]
@@ -106,14 +107,14 @@ pub fn Icon(
     #[doc = r""]
     #[doc = r" This can be useful in RTL languages where normal"]
     #[doc = r" icon orientation is not appropriate."]
-    # [prop (into , default = MaybeSignal :: Static (false))]
-    mirrored: MaybeSignal<bool>,
+    # [prop (into , default = Signal::from (false))]
+    mirrored: Signal<bool>,
     #[doc = r" The HTML ID of the underlying SVG element."]
     #[prop(into, optional)]
-    id: MaybeProp<TextProp>,
+    id: TextProp,
     #[doc = r" The CSS class property of the underlying SVG element."]
     #[prop(into, optional)]
-    class: MaybeProp<TextProp>,
+    class: TextProp,
 ) -> impl IntoView {
     let html = move || icon.get(weight.get());
     let transform = move || mirrored.get().then_some("scale(-1, 1)");
@@ -123,11 +124,11 @@ pub fn Icon(
             xmlns="http://www.w3.org/2000/svg"
             width=move || size.get()
             height=move || height.get()
-            fill=color
+            fill=move || color.get()
             transform=transform
             viewBox="0 0 256 256"
-            id=move || id.get().map(|id| id.get())
-            class=move || class.get().map(|cls| cls.get())
+            id=move || id.get()
+            class=move || class.get()
             inner_html=html
         ></svg>
     }

--- a/xtask/src/update.rs
+++ b/xtask/src/update.rs
@@ -55,7 +55,7 @@ exclude = ["/core"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = "0.6"
+leptos = "0.7.1"
 
 [workspace]
 members = ["xtask"]
@@ -201,7 +201,7 @@ pub fn run() {
         //! You can explore the available icons at [phosphoricons.com](https://phosphoricons.com).
         //!
         //! ```
-        //! use leptos::*;
+        //! use leptos::prelude::*;
         //! use phosphor_leptos::{Icon, IconWeight, HORSE, HEART, CUBE};
         //!
         //! #[component]
@@ -213,7 +213,8 @@ pub fn run() {
         //!     }
         //! }
         //! ```
-        use leptos::*;
+        use leptos::prelude::*;
+        use leptos::text_prop::TextProp;
 
         mod icons;
         pub use icons::*;
@@ -236,7 +237,7 @@ pub fn run() {
             /// an SVG component's `inner_html` property.
             ///
             /// ```
-            /// # use leptos::*;
+            /// # use leptos::prelude::*;
             /// # #[component]
             /// # fn MyComponent() -> impl IntoView {
             /// use phosphor_leptos::{ACORN, IconWeight};
@@ -263,7 +264,7 @@ pub fn run() {
         /// A thin wrapper around `<svg />` for displaying Phosphor icons.
         ///
         /// ```
-        /// use leptos::*;
+        /// use leptos::prelude::*;
         /// use phosphor_leptos::{Icon, IconWeight, HORSE, HEART, CUBE};
         ///
         /// #[component]
@@ -283,7 +284,7 @@ pub fn run() {
             /// Icon weight/style. This can also be used, for example, to "toggle" an icon's state:
             /// a rating component could use Stars with [IconWeight::Regular] to denote an empty star,
             /// and [IconWeight::Fill] to denote a filled star.
-            #[prop(into, default = MaybeSignal::Static(IconWeight::Regular))] weight: MaybeSignal<
+            #[prop(into, default = Signal::from (IconWeight::Regular))] weight: Signal<
                 IconWeight,
             >,
 
@@ -304,13 +305,13 @@ pub fn run() {
             ///
             /// This can be useful in RTL languages where normal
             /// icon orientation is not appropriate.
-            #[prop(into, default = MaybeSignal::Static(false))] mirrored: MaybeSignal<bool>,
+            #[prop(into, default = Signal::from(false))] mirrored: Signal<bool>,
 
             /// The HTML ID of the underlying SVG element.
-            #[prop(into, optional)] id: MaybeProp<TextProp>,
+            #[prop(into, optional)] id: TextProp,
 
             /// The CSS class property of the underlying SVG element.
-            #[prop(into, optional)] class: MaybeProp<TextProp>,
+            #[prop(into, optional)] class: TextProp,
         ) -> impl IntoView {
             let html = move || icon.get(weight.get());
             let transform = move || mirrored.get().then_some("scale(-1, 1)");


### PR DESCRIPTION
Change crate depend to 0.7.1 so it does not allow 0.8.x. Now it allows to use the it with Leptos 0.X and this is incorrect.