### PR TITLE
Restore the removed id and class attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,12 @@ pub fn Icon(
     #[doc = r" icon orientation is not appropriate."]
     # [prop (into , default = Signal :: stored (false))]
     mirrored: Signal<bool>,
+    #[doc = r" The HTML ID of the underlying SVG element."]
+    #[prop(into, optional)]
+    id: TextProp,
+    #[doc = r" The CSS class property of the underlying SVG element."]
+    #[prop(into, optional)]
+    class: TextProp,
 ) -> impl IntoView {
     let html = move || icon.get(weight.get());
     let transform = move || mirrored.get().then_some("scale(-1, 1)");
@@ -120,6 +126,8 @@ pub fn Icon(
             fill=move || color.get()
             transform=transform
             viewBox="0 0 256 256"
+            id=move || id.get()
+            class=move || class.get()
             inner_html=html
         />
     }

--- a/xtask/src/update.rs
+++ b/xtask/src/update.rs
@@ -318,6 +318,12 @@ pub fn run() {
             /// This can be useful in RTL languages where normal
             /// icon orientation is not appropriate.
             #[prop(into, default = Signal::stored(false))] mirrored: Signal<bool>,
+
+            /// The HTML ID of the underlying SVG element.
+            #[prop(into, optional)] id: TextProp,
+
+            /// The CSS class property of the underlying SVG element.
+            #[prop(into, optional)] class: TextProp,
         ) -> impl IntoView {
             let html = move || icon.get(weight.get());
             let transform = move || mirrored.get().then_some("scale(-1, 1)");
@@ -331,6 +337,8 @@ pub fn run() {
                     fill=move || color.get()
                     transform=transform
                     viewBox="0 0 256 256"
+                    id=move || id.get()
+                    class=move || class.get()
                     inner_html=html
                 />
             }


### PR DESCRIPTION
In PR #16 the `id` and `class` attributes are removed.