### PR TITLE
updated project to use leptos 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "phosphor-leptos"
-version = "0.7.0"
+version = "0.8.0"
 description = "phosphor icons for leptos"
 authors = ["Søren H. Hansen"]
 readme = "README.md"
@@ -16,7 +16,7 @@ exclude = ["/core"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = "0.7"
+leptos = "0.8"
 
 [workspace]
 members = ["xtask"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Phosphor is a flexible icon family for interfaces, diagrams, presentations — w
 ## Installation
 
 ```bash
-phosphor-leptos = "0.7.0"
+phosphor-leptos = "0.8.0"
 ```
 
 or

--- a/xtask/src/update.rs
+++ b/xtask/src/update.rs
@@ -42,7 +42,7 @@ fn cargo_template(features: &BTreeMap<String, ()>) -> String {
 
 [package]
 name = "phosphor-leptos"
-version = "0.7.0"
+version = "0.8.0"
 description = "phosphor icons for leptos"
 authors = ["Søren H. Hansen"]
 readme = "README.md"
@@ -55,7 +55,7 @@ exclude = ["/core"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = "0.7"
+leptos = "0.8"
 
 [workspace]
 members = ["xtask"]


### PR DESCRIPTION
hey - I upgraded the project to use leptos 0.8.

Unfortunately I wasn't able to test it, because somehow the icons didn't render at all, even when I used leptos 0.7.7 and phosphor-leptos 0.7.0. These versions worked fine in another project. Can't test it there though, because other dependencies haven't been upgraded to 0.8 as well.

I don't know if I broke something on my local machine, or why the icons don't render. The svg's are just empty. However, the path string renders just fine.

I created an example project [here](https://github.com/FloWi/phosphor-icons-playground).
Would you mind taking a look at its README? I added a screenshot that shows the issue.

The only difference is the test-project being frontend-only, where my other project uses ssr.